### PR TITLE
Add v0.next core systems: 12 issues implemented

### DIFF
--- a/components/BarracksScreen.jsx
+++ b/components/BarracksScreen.jsx
@@ -2,11 +2,13 @@
 
 import { useState } from "react";
 import { useGameState, useGameDispatch } from "@/lib/gameContext";
-import { getEffectiveStats, getHeroPower, canLevelUp, getUnequippedItems } from "@/lib/hero";
+import { getEffectiveStats, getHeroPower, canLevelUp, getUnequippedItems, getRestDuration, getPotionCost } from "@/lib/hero";
 import { getHeroTemplate } from "@/lib/hero";
+import { getUnlockedTitles, getTitleById } from "@/data/titles";
 import { getHeroLevelCost } from "@/data/progression";
 import { HERO_TEMPLATES } from "@/data/heroes";
 import { getRarityColor } from "@/lib/rarity";
+import { RESOURCES } from "@/data/resources";
 import { getHeroSkills } from "@/lib/skills";
 import HeroCard from "./shared/HeroCard";
 import ItemCard from "./shared/ItemCard";
@@ -17,8 +19,11 @@ import styles from "./BarracksScreen.module.css";
 export default function BarracksScreen() {
   const state = useGameState();
   const dispatch = useGameDispatch();
-  const [selectedHeroId, setSelectedHeroId] = useState(state.heroes[0]?.id || null);
+  const [selectedHeroId, setSelectedHeroId] = useState(
+    state.screenPayload?.heroId || state.heroes[0]?.id || null
+  );
   const [equipSlot, setEquipSlot] = useState(null); // 'weapon' | 'armor' | 'accessory' | null
+  const [showTitlePicker, setShowTitlePicker] = useState(false);
 
   const selectedHero = state.heroes.find((h) => h.id === selectedHeroId);
   const effectiveStats = selectedHero ? getEffectiveStats(selectedHero, state.inventory) : null;
@@ -34,6 +39,7 @@ export default function BarracksScreen() {
       heroId: selectedHero.id,
       cost,
       statGrowth: template.statGrowth,
+      enduranceGrowth: template.enduranceGrowth || 5,
     });
   };
 
@@ -109,6 +115,93 @@ export default function BarracksScreen() {
             </div>
           </div>
 
+          {/* Endurance */}
+          {(() => {
+            const endurance = selectedHero.endurance || { current: 100, max: 100 };
+            const pct = (endurance.current / endurance.max) * 100;
+            const isResting = selectedHero.status === "resting";
+            const restRemaining = isResting && selectedHero.restUntil
+              ? Math.max(0, Math.ceil((selectedHero.restUntil - Date.now()) / 1000))
+              : 0;
+            const potCost = getPotionCost(selectedHero);
+            const canAffordPotion = Object.entries(potCost).every(
+              ([res, amt]) => (state.resources[res] || 0) >= amt
+            );
+            const needsRecovery = endurance.current < endurance.max;
+
+            return (
+              <div className={styles.enduranceSection}>
+                <div className={styles.enduranceHeader}>
+                  <span className={styles.enduranceLabel}>Endurance</span>
+                  <span className={styles.enduranceValue}>{endurance.current}/{endurance.max}</span>
+                </div>
+                <div className={styles.enduranceBar}>
+                  <div
+                    className={styles.enduranceFill}
+                    style={{
+                      width: `${pct}%`,
+                      background: pct <= 20 ? "#ef4444" : pct <= 50 ? "#f59e0b" : "#22c55e",
+                    }}
+                  />
+                </div>
+                {isResting && (
+                  <p className={styles.restingNote}>Resting... {restRemaining}s remaining</p>
+                )}
+                {needsRecovery && selectedHero.status === "idle" && (
+                  <div className={styles.enduranceActions}>
+                    <button
+                      className={styles.restBtn}
+                      onClick={() => dispatch({
+                        type: "REST_HERO",
+                        heroId: selectedHero.id,
+                        duration: getRestDuration(selectedHero),
+                      })}
+                    >
+                      Rest ({Math.ceil(getRestDuration(selectedHero) / 1000)}s)
+                    </button>
+                    <button
+                      className={styles.potionBtn}
+                      disabled={!canAffordPotion}
+                      onClick={() => dispatch({
+                        type: "USE_POTION",
+                        heroId: selectedHero.id,
+                        cost: potCost,
+                      })}
+                    >
+                      Potion ({Object.entries(potCost).filter(([,v]) => v > 0).map(([res, amt]) => `${RESOURCES[res]?.icon || res} ${amt}`).join(" ")})
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+
+          {/* Title */}
+          {(() => {
+            const unlockedTitles = getUnlockedTitles(state.stats, state.worldMap, state.prestige);
+            const currentTitle = selectedHero.activeTitle ? getTitleById(selectedHero.activeTitle) : null;
+            return (
+              <div className={styles.titleSection}>
+                <div className={styles.titleHeader}>
+                  <span className={styles.titleLabel}>Title</span>
+                  <button
+                    className={styles.titlePickerBtn}
+                    onClick={() => setShowTitlePicker(true)}
+                    disabled={unlockedTitles.length === 0}
+                  >
+                    {currentTitle ? currentTitle.name : "None"} {unlockedTitles.length > 0 ? "\u25BE" : ""}
+                  </button>
+                </div>
+                {currentTitle && (
+                  <span className={styles.titleBonus}>{currentTitle.bonus.label}</span>
+                )}
+                {unlockedTitles.length === 0 && (
+                  <span className={styles.titleHint}>Complete milestones to earn titles</span>
+                )}
+              </div>
+            );
+          })()}
+
           {/* Skills */}
           <h4 className={styles.subheading}>Skills</h4>
           <div className={styles.skillList}>
@@ -137,7 +230,7 @@ export default function BarracksScreen() {
                         className={styles.equippedName}
                         style={{ color: getRarityColor(item.rarity) }}
                       >
-                        {item.icon} {item.name}
+                        {item.icon} {item.name}{(item.level || 1) > 1 ? ` Lv.${item.level}` : ""}
                       </span>
                       <button
                         className={styles.unequipBtn}
@@ -165,7 +258,7 @@ export default function BarracksScreen() {
           <button
             className={styles.levelUpBtn}
             onClick={handleLevelUp}
-            disabled={!canLevel || selectedHero.status === "expedition"}
+            disabled={!canLevel || selectedHero.status !== "idle"}
           >
             Level Up ({"\u{1FA99}"} {levelCost})
           </button>
@@ -187,6 +280,38 @@ export default function BarracksScreen() {
                 />
               ))
             )}
+          </div>
+        </Modal>
+      )}
+
+      {/* Title Picker Modal */}
+      {showTitlePicker && selectedHero && (
+        <Modal title="Choose Title" onClose={() => setShowTitlePicker(false)}>
+          <div className={styles.titlePicker}>
+            <button
+              className={`${styles.titleOption} ${!selectedHero.activeTitle ? styles.titleActive : ""}`}
+              onClick={() => {
+                dispatch({ type: "SET_ACTIVE_TITLE", heroId: selectedHero.id, titleId: null });
+                setShowTitlePicker(false);
+              }}
+            >
+              <span className={styles.titleOptName}>None</span>
+              <span className={styles.titleOptDesc}>No title bonus</span>
+            </button>
+            {getUnlockedTitles(state.stats, state.worldMap, state.prestige).map((title) => (
+              <button
+                key={title.id}
+                className={`${styles.titleOption} ${selectedHero.activeTitle === title.id ? styles.titleActive : ""}`}
+                onClick={() => {
+                  dispatch({ type: "SET_ACTIVE_TITLE", heroId: selectedHero.id, titleId: title.id });
+                  setShowTitlePicker(false);
+                }}
+              >
+                <span className={styles.titleOptName}>{title.name}</span>
+                <span className={styles.titleOptDesc}>{title.description}</span>
+                <span className={styles.titleOptBonus}>{title.bonus.label}</span>
+              </button>
+            ))}
           </div>
         </Modal>
       )}

--- a/components/BarracksScreen.module.css
+++ b/components/BarracksScreen.module.css
@@ -77,6 +77,194 @@
 .statLabel { font-size: 0.55rem; color: #6b6b80; text-transform: uppercase; }
 .statValue { font-size: 0.85rem; font-weight: 700; color: #e8e8f0; font-variant-numeric: tabular-nums; }
 
+/* Endurance */
+.enduranceSection {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.enduranceHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.enduranceLabel {
+  font-size: 0.65rem;
+  color: #8888a0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.enduranceValue {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #a0a0b8;
+  font-variant-numeric: tabular-nums;
+}
+
+.enduranceBar {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.enduranceFill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.restingNote {
+  font-size: 0.65rem;
+  color: #f59e0b;
+  text-align: center;
+  margin: 0;
+}
+
+.enduranceActions {
+  display: flex;
+  gap: 6px;
+}
+
+.restBtn {
+  flex: 1;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(107, 114, 128, 0.15);
+  color: #9ca3af;
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.restBtn:active {
+  background: rgba(107, 114, 128, 0.25);
+}
+
+.potionBtn {
+  flex: 1;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.potionBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.potionBtn:active:not(:disabled) {
+  background: rgba(34, 197, 94, 0.25);
+}
+
+/* Title */
+.titleSection {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.titleHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.titleLabel {
+  font-size: 0.65rem;
+  color: #8888a0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.titlePickerBtn {
+  background: rgba(168, 85, 247, 0.12);
+  border: 1px solid rgba(168, 85, 247, 0.2);
+  color: #a855f7;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.titlePickerBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.titleBonus {
+  font-size: 0.65rem;
+  color: #22c55e;
+  text-align: right;
+}
+
+.titleHint {
+  font-size: 0.6rem;
+  color: #6b6b80;
+  font-style: italic;
+}
+
+/* Title Picker */
+.titlePicker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.titleOption {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 10px;
+  text-align: left;
+  color: #e8e8f0;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.titleOption:active {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.titleActive {
+  border-color: #a855f7;
+  box-shadow: 0 0 10px rgba(168, 85, 247, 0.15);
+}
+
+.titleOptName {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #a855f7;
+}
+
+.titleOptDesc {
+  font-size: 0.65rem;
+  color: #8888a0;
+}
+
+.titleOptBonus {
+  font-size: 0.65rem;
+  color: #22c55e;
+  font-weight: 600;
+}
+
 /* Skills */
 .skillList {
   display: flex;

--- a/components/CombatReplayModal.jsx
+++ b/components/CombatReplayModal.jsx
@@ -52,6 +52,11 @@ export default function CombatReplayModal({ combatResult, rewards, onDone }) {
   const resultLabel = victory ? "Victory!" : isDraw ? "Draw" : "Defeat";
   const resultColor = victory ? "#22c55e" : isDraw ? "#f59e0b" : "#ef4444";
   const multLabel = victory ? "1.5x" : isDraw ? "0.75x" : "0.5x";
+  const consequenceLabel = victory
+    ? null
+    : isDraw
+    ? "1.5x durability & endurance drain, no item drops"
+    : "2x durability & endurance drain, no item drops";
 
   return (
     <Modal title="Combat" onClose={onDone}>
@@ -98,6 +103,9 @@ export default function CombatReplayModal({ combatResult, rewards, onDone }) {
             <span className={styles.multiplier} style={{ color: resultColor }}>
               Rewards {multLabel}
             </span>
+            {consequenceLabel && (
+              <span className={styles.consequence}>{consequenceLabel}</span>
+            )}
             <button className={styles.doneBtn} onClick={onDone}>
               Claim Rewards
             </button>

--- a/components/CombatReplayModal.module.css
+++ b/components/CombatReplayModal.module.css
@@ -119,6 +119,13 @@
   font-weight: 700;
 }
 
+.consequence {
+  font-size: 0.6rem;
+  color: #a0a0b8;
+  text-align: center;
+  font-style: italic;
+}
+
 .doneBtn {
   width: 100%;
   margin-top: 8px;

--- a/components/ForgeScreen.jsx
+++ b/components/ForgeScreen.jsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useGameState, useGameDispatch } from "@/lib/gameContext";
 import { canCraft, getAvailableRecipes, generateItem, getCraftRefund, getRecipeById } from "@/lib/crafting";
-import { getSellValue, getRarityColor, getRarityLabel } from "@/lib/rarity";
+import { getSellValue, getRarityColor, getRarityLabel, getUpgradeCost, getRepairCost, getDismantleReturns } from "@/lib/rarity";
 import { RESOURCES } from "@/data/resources";
 import ItemCard from "./shared/ItemCard";
 import Modal from "./shared/Modal";
@@ -14,6 +14,9 @@ export default function ForgeScreen() {
   const dispatch = useGameDispatch();
   const [selectedItem, setSelectedItem] = useState(null);
   const [tab, setTab] = useState("recipes"); // 'recipes' | 'inventory'
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const longPressRef = useRef(null);
 
   const recipes = getAvailableRecipes(state.player.level);
 
@@ -38,9 +41,67 @@ export default function ForgeScreen() {
 
   const handleSell = (item) => {
     const recipe = getRecipeById(item.recipeId);
-    const goldValue = recipe ? getSellValue(recipe, item.rarity) : 5;
+    const goldValue = recipe ? getSellValue(recipe, item.rarity, item.level) : 5;
     dispatch({ type: "SELL_ITEM", itemId: item.id, goldValue });
     setSelectedItem(null);
+  };
+
+  const handleUpgrade = (item) => {
+    const cost = getUpgradeCost(item);
+    if (!cost) return;
+    dispatch({ type: "UPGRADE_ITEM", itemId: item.id, cost });
+    setSelectedItem(null);
+  };
+
+  const handleRepair = (item) => {
+    const cost = getRepairCost(item);
+    if (!cost) return;
+    dispatch({ type: "REPAIR_ITEM", itemId: item.id, cost });
+    setSelectedItem(null);
+  };
+
+  const handleDismantle = (item) => {
+    const returns = getDismantleReturns(item);
+    dispatch({ type: "DISMANTLE_ITEM", itemId: item.id, returns });
+    setSelectedItem(null);
+  };
+
+  const handleBatchSell = () => {
+    const items = state.inventory.filter((i) => selectedIds.has(i.id) && !i.equippedBy);
+    if (items.length === 0) return;
+    let totalGold = 0;
+    const itemIds = [];
+    for (const item of items) {
+      const recipe = getRecipeById(item.recipeId);
+      totalGold += recipe ? getSellValue(recipe, item.rarity, item.level) : 5;
+      itemIds.push(item.id);
+    }
+    dispatch({ type: "SELL_ITEMS_BATCH", itemIds, totalGold });
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  };
+
+  const toggleSelection = (itemId) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  };
+
+  const handleItemInteraction = (item) => {
+    if (selectionMode) {
+      if (!item.equippedBy) toggleSelection(item.id);
+    } else {
+      setSelectedItem(item);
+    }
+  };
+
+  const handleLongPress = (item) => {
+    if (item.equippedBy) return;
+    setSelectionMode(true);
+    setSelectedIds(new Set([item.id]));
   };
 
   const now = Date.now();
@@ -102,7 +163,7 @@ export default function ForgeScreen() {
           className={`${styles.tab} ${tab === "inventory" ? styles.tabActive : ""}`}
           onClick={() => setTab("inventory")}
         >
-          Inventory ({state.inventory.length})
+          Inventory ({state.inventory.length}/{state.inventoryCapacity || 20})
         </button>
       </div>
 
@@ -112,6 +173,7 @@ export default function ForgeScreen() {
           {recipes.map((recipe) => {
             const affordable = canCraft(recipe, state.resources);
             const queueFull = state.craftingQueue.length >= 2;
+            const invFull = state.inventory.length >= (state.inventoryCapacity || 20);
 
             return (
               <div key={recipe.id} className={styles.recipeCard}>
@@ -143,10 +205,10 @@ export default function ForgeScreen() {
                 </div>
                 <button
                   className={styles.craftBtn}
-                  disabled={!affordable || queueFull}
+                  disabled={!affordable || queueFull || invFull}
                   onClick={() => handleCraft(recipe)}
                 >
-                  {queueFull ? "Queue Full" : affordable ? "Craft" : "Need Resources"}
+                  {invFull ? "Inventory Full" : queueFull ? "Queue Full" : affordable ? "Craft" : "Need Resources"}
                 </button>
               </div>
             );
@@ -161,13 +223,57 @@ export default function ForgeScreen() {
             <p className={styles.empty}>No items yet. Start crafting!</p>
           ) : (
             state.inventory.map((item) => (
-              <ItemCard
+              <div
                 key={item.id}
-                item={item}
-                onClick={() => setSelectedItem(item)}
-              />
+                className={`${styles.selectableItem} ${selectionMode && selectedIds.has(item.id) ? styles.itemSelected : ""}`}
+                onPointerDown={() => {
+                  longPressRef.current = setTimeout(() => handleLongPress(item), 400);
+                }}
+                onPointerUp={() => clearTimeout(longPressRef.current)}
+                onPointerLeave={() => clearTimeout(longPressRef.current)}
+              >
+                {selectionMode && !item.equippedBy && (
+                  <span className={styles.selectCheck}>
+                    {selectedIds.has(item.id) ? "\u2611" : "\u2610"}
+                  </span>
+                )}
+                <ItemCard
+                  item={item}
+                  onClick={() => handleItemInteraction(item)}
+                />
+              </div>
             ))
           )}
+        </div>
+      )}
+
+      {/* Batch Sell Bar */}
+      {selectionMode && (
+        <div className={styles.batchBar}>
+          <span className={styles.batchCount}>
+            {selectedIds.size} item{selectedIds.size !== 1 ? "s" : ""} selected
+          </span>
+          <div className={styles.batchActions}>
+            <button
+              className={styles.batchCancel}
+              onClick={() => { setSelectionMode(false); setSelectedIds(new Set()); }}
+            >
+              Cancel
+            </button>
+            <button
+              className={styles.batchSellBtn}
+              disabled={selectedIds.size === 0}
+              onClick={handleBatchSell}
+            >
+              Sell All ({"\u{1FA99}"}{" "}
+              {state.inventory
+                .filter((i) => selectedIds.has(i.id) && !i.equippedBy)
+                .reduce((sum, item) => {
+                  const recipe = getRecipeById(item.recipeId);
+                  return sum + (recipe ? getSellValue(recipe, item.rarity, item.level) : 5);
+                }, 0)})
+            </button>
+          </div>
         </div>
       )}
 
@@ -184,7 +290,9 @@ export default function ForgeScreen() {
                 >
                   {getRarityLabel(selectedItem.rarity)}
                 </span>
-                <span className={styles.itemDetailSlot}>{selectedItem.slot}</span>
+                <span className={styles.itemDetailSlot}>
+                  {selectedItem.slot}{(selectedItem.level || 1) > 1 ? ` \u00B7 Lv.${selectedItem.level}` : ""}
+                </span>
               </div>
             </div>
             <div className={styles.itemDetailStats}>
@@ -199,6 +307,79 @@ export default function ForgeScreen() {
                 ) : null
               )}
             </div>
+            {/* Durability */}
+            {selectedItem.durability && (
+              <div className={styles.durabilitySection}>
+                <div className={styles.durabilityHeader}>
+                  <span className={styles.durabilityLabel}>Durability</span>
+                  <span className={styles.durabilityValue}>
+                    {selectedItem.durability.current}/{selectedItem.durability.max}
+                  </span>
+                </div>
+                <div className={styles.durabilityBarLarge}>
+                  <div
+                    className={styles.durabilityFillLarge}
+                    style={{
+                      width: `${(selectedItem.durability.current / selectedItem.durability.max) * 100}%`,
+                      background: selectedItem.durability.current <= 0
+                        ? "#ef4444"
+                        : selectedItem.durability.current < selectedItem.durability.max * 0.3
+                        ? "#f59e0b"
+                        : "#22c55e",
+                    }}
+                  />
+                </div>
+                {selectedItem.durability.current <= 0 && (
+                  <p className={styles.brokenNote}>Broken — no stat bonus until repaired</p>
+                )}
+                {(() => {
+                  const repCost = getRepairCost(selectedItem);
+                  if (!repCost) return null;
+                  const canAffordRepair = Object.entries(repCost).every(
+                    ([res, amt]) => (state.resources[res] || 0) >= amt
+                  );
+                  return (
+                    <button
+                      className={styles.repairBtn}
+                      disabled={!canAffordRepair}
+                      onClick={() => handleRepair(selectedItem)}
+                    >
+                      Repair ({Object.entries(repCost).filter(([,v]) => v > 0).map(([res, amt]) => `${RESOURCES[res]?.icon || res} ${amt}`).join(" ")})
+                    </button>
+                  );
+                })()}
+              </div>
+            )}
+
+            {/* Dismantle button */}
+            {!selectedItem.equippedBy && (
+              <button
+                className={styles.dismantleBtn}
+                onClick={() => handleDismantle(selectedItem)}
+              >
+                Dismantle ({Object.entries(getDismantleReturns(selectedItem)).filter(([,v]) => v > 0).map(([res, amt]) => `${RESOURCES[res]?.icon || res} ${amt}`).join(" ")})
+              </button>
+            )}
+
+            {/* Upgrade button */}
+            {(() => {
+              const upgradeCost = getUpgradeCost(selectedItem);
+              if (!upgradeCost) return null;
+              const canAfford = Object.entries(upgradeCost).every(
+                ([res, amt]) => amt === 0 || (state.resources[res] || 0) >= amt
+              );
+              return (
+                <button
+                  className={styles.upgradeBtn}
+                  disabled={!canAfford || !!selectedItem.equippedBy}
+                  onClick={() => handleUpgrade(selectedItem)}
+                >
+                  Upgrade to Lv.{(selectedItem.level || 1) + 1}
+                  {" ("}{Object.entries(upgradeCost).filter(([,v]) => v > 0).map(([res, amt]) => `${RESOURCES[res]?.icon || res} ${amt}`).join(" ")}{")"}
+                </button>
+              );
+            })()}
+
             {selectedItem.equippedBy ? (
               <p className={styles.equippedNote}>Currently equipped</p>
             ) : (
@@ -206,7 +387,7 @@ export default function ForgeScreen() {
                 className={styles.sellBtn}
                 onClick={() => handleSell(selectedItem)}
               >
-                Sell for {getSellValue(getRecipeById(selectedItem.recipeId) || { ingredients: {}, tier: 1 }, selectedItem.rarity)} {"\u{1FA99}"}
+                Sell for {getSellValue(getRecipeById(selectedItem.recipeId) || { ingredients: {}, tier: 1 }, selectedItem.rarity, selectedItem.level)} {"\u{1FA99}"}
               </button>
             )}
           </div>

--- a/components/ForgeScreen.module.css
+++ b/components/ForgeScreen.module.css
@@ -272,6 +272,110 @@
   text-align: center;
 }
 
+.durabilitySection {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.durabilityHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.durabilityLabel {
+  font-size: 0.65rem;
+  color: #8888a0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.durabilityValue {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #a0a0b8;
+  font-variant-numeric: tabular-nums;
+}
+
+.durabilityBarLarge {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.durabilityFillLarge {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.brokenNote {
+  font-size: 0.65rem;
+  color: #ef4444;
+  text-align: center;
+  margin: 0;
+}
+
+.repairBtn {
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.repairBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.repairBtn:active:not(:disabled) {
+  background: rgba(34, 197, 94, 0.25);
+}
+
+.dismantleBtn {
+  width: 100%;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(168, 85, 247, 0.15);
+  color: #a855f7;
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dismantleBtn:active {
+  background: rgba(168, 85, 247, 0.25);
+}
+
+.upgradeBtn {
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+  font-size: 0.75rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.upgradeBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.upgradeBtn:active:not(:disabled) {
+  background: rgba(59, 130, 246, 0.25);
+}
+
 .sellBtn {
   width: 100%;
   padding: 10px;
@@ -286,4 +390,85 @@
 
 .sellBtn:active {
   background: rgba(239, 68, 68, 0.25);
+}
+
+/* Selection Mode */
+.selectableItem {
+  position: relative;
+  border-radius: 10px;
+  transition: background 0.15s;
+}
+
+.itemSelected {
+  background: rgba(59, 130, 246, 0.1);
+  outline: 2px solid rgba(59, 130, 246, 0.4);
+  border-radius: 10px;
+}
+
+.selectCheck {
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  z-index: 1;
+  font-size: 1rem;
+  color: #3b82f6;
+}
+
+/* Batch Sell Bar */
+.batchBar {
+  position: fixed;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  background: rgba(15, 15, 25, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 50;
+  animation: slideUp 0.2s ease;
+}
+
+.batchCount {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #a0a0b8;
+}
+
+.batchActions {
+  display: flex;
+  gap: 8px;
+}
+
+.batchCancel {
+  padding: 8px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: none;
+  color: #a0a0b8;
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.batchSellBtn {
+  padding: 8px 14px;
+  border: none;
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.batchSellBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
 }

--- a/components/HubScreen.jsx
+++ b/components/HubScreen.jsx
@@ -2,6 +2,9 @@
 
 import { useGameState, useGameDispatch } from "@/lib/gameContext";
 import { XP_TABLE, LEVEL_UNLOCKS } from "@/data/progression";
+import { EXPEDITIONS } from "@/data/expeditions";
+import { rollRarity, applyRarityMultiplier, getMaxDurability } from "@/lib/rarity";
+import { RECIPES } from "@/data/recipes";
 import ProgressBar from "./shared/ProgressBar";
 import PrestigePanel from "./PrestigePanel";
 import styles from "./HubScreen.module.css";
@@ -37,6 +40,47 @@ function getNextUnlock(playerLevel) {
     }
   }
   return null;
+}
+
+const CHEST_CONFIG = {
+  common: { icon: "\u{1F4E6}", label: "Common Chest", color: "#9ca3af", resources: { gold: [10, 25], wood: [10, 20] } },
+  uncommon: { icon: "\u{1F381}", label: "Uncommon Chest", color: "#22c55e", resources: { gold: [25, 60], iron: [10, 20], herbs: [5, 15] } },
+  rare: { icon: "\u{1F3C6}", label: "Rare Chest", color: "#3b82f6", resources: { gold: [60, 120], gems: [2, 5], iron: [15, 30] } },
+};
+
+function generateChestRewards(chestType, playerLevel) {
+  const config = CHEST_CONFIG[chestType];
+  const resources = {};
+  for (const [res, [min, max]] of Object.entries(config.resources)) {
+    resources[res] = Math.round(min + Math.random() * (max - min));
+  }
+
+  const items = [];
+  // Rare chests have a 40% item drop, uncommon 15%, common 0%
+  const itemChance = chestType === "rare" ? 0.4 : chestType === "uncommon" ? 0.15 : 0;
+  if (Math.random() < itemChance) {
+    const eligible = RECIPES.filter((r) => r.unlockLevel <= playerLevel);
+    if (eligible.length > 0) {
+      const recipe = eligible[Math.floor(Math.random() * eligible.length)];
+      const rarity = rollRarity();
+      const maxDur = getMaxDurability(recipe.tier, rarity.id);
+      items.push({
+        id: `item_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        recipeId: recipe.id,
+        name: recipe.name,
+        icon: recipe.icon,
+        slot: recipe.slot,
+        tier: recipe.tier,
+        rarity: rarity.id,
+        level: 1,
+        durability: { current: maxDur, max: maxDur },
+        stats: applyRarityMultiplier(recipe.baseStats, rarity),
+        equippedBy: null,
+      });
+    }
+  }
+
+  return { resources, items };
 }
 
 export default function HubScreen({ onOpenSettings }) {
@@ -96,6 +140,49 @@ export default function HubScreen({ onOpenSettings }) {
         </div>
       )}
 
+      {/* Active Expeditions Banner */}
+      {expeditions.active.length > 0 && (
+        <div className={styles.expeditionBanner}>
+          <div className={styles.bannerHeader}>
+            <span className={styles.bannerIcon}>{"\u{1F5FA}\uFE0F"}</span>
+            <span className={styles.bannerTitle}>Active Expeditions</span>
+            {player.unlockedScreens.includes("expedition") && (
+              <button
+                className={styles.bannerViewBtn}
+                onClick={() => dispatch({ type: "SET_SCREEN", screen: "expedition" })}
+              >
+                View
+              </button>
+            )}
+          </div>
+          {expeditions.active.map((exp) => {
+            const template = EXPEDITIONS.find((e) => e.id === exp.templateId);
+            const now = Date.now();
+            const remaining = Math.max(0, (exp.startedAt + exp.duration) - now);
+            const pct = Math.min(((now - exp.startedAt) / exp.duration) * 100, 100);
+            const sec = Math.ceil(remaining / 1000);
+            const min = Math.floor(sec / 60);
+            const timeLabel = min > 0 ? `${min}m ${sec % 60}s` : `${sec}s`;
+
+            return (
+              <div key={exp.id} className={styles.expCard}>
+                <div className={styles.expInfo}>
+                  <span className={styles.expIcon}>{template?.icon || "?"}</span>
+                  <span className={styles.expName}>{template?.name || "Unknown"}</span>
+                  <span className={styles.expTime}>{remaining > 0 ? timeLabel : "Done!"}</span>
+                </div>
+                <div className={styles.expBar}>
+                  <div
+                    className={styles.expFill}
+                    style={{ width: `${pct}%`, background: remaining <= 0 ? "#22c55e" : "#f59e0b" }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
       {/* Next Goal */}
       {(() => {
         const goal = getNextGoal(player);
@@ -128,6 +215,46 @@ export default function HubScreen({ onOpenSettings }) {
           </div>
         );
       })()}
+
+      {/* Loot Chests */}
+      {state.chests && (
+        <div className={styles.chestsSection}>
+          <h3 className={styles.sectionTitle}>Loot Chests</h3>
+          <div className={styles.chestList}>
+            {Object.entries(state.chests).map(([type, chest]) => {
+              const config = CHEST_CONFIG[type];
+              const now = Date.now();
+              const remaining = Math.max(0, chest.cooldown - (now - chest.lastClaimed));
+              const ready = remaining <= 0;
+              const hrs = Math.floor(remaining / 3600000);
+              const mins = Math.floor((remaining % 3600000) / 60000);
+              const timeLabel = hrs > 0 ? `${hrs}h ${mins}m` : `${mins}m`;
+
+              return (
+                <button
+                  key={type}
+                  className={`${styles.chestCard} ${ready ? styles.chestReady : ""}`}
+                  style={{ "--chest-color": config.color }}
+                  disabled={!ready}
+                  onClick={() => {
+                    if (!ready) return;
+                    const rewards = generateChestRewards(type, player.level);
+                    dispatch({ type: "CLAIM_CHEST", chestType: type, rewards });
+                  }}
+                >
+                  <span className={styles.chestIcon}>{config.icon}</span>
+                  <div className={styles.chestInfo}>
+                    <span className={styles.chestLabel}>{config.label}</span>
+                    <span className={styles.chestTimer} style={{ color: ready ? "#22c55e" : "#8888a0" }}>
+                      {ready ? "Ready!" : timeLabel}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Nav Tiles */}
       <div className={styles.grid}>
@@ -168,13 +295,17 @@ export default function HubScreen({ onOpenSettings }) {
         <h3 className={styles.sectionTitle}>Heroes</h3>
         <div className={styles.heroList}>
           {state.heroes.map((hero) => (
-            <div key={hero.id} className={styles.heroChip}>
+            <button
+              key={hero.id}
+              className={styles.heroChip}
+              onClick={() => dispatch({ type: "SET_SCREEN", screen: "barracks", payload: { heroId: hero.id } })}
+            >
               <span className={styles.heroStatus}>
-                {hero.status === "expedition" ? "\u{1F6B6}" : "\u{1F9D1}\u200D\u2694\uFE0F"}
+                {hero.status === "expedition" ? "\u{1F6B6}" : hero.status === "resting" ? "\u{1F4A4}" : "\u{1F9D1}\u200D\u2694\uFE0F"}
               </span>
               <span>{hero.name}</span>
               <span className={styles.heroLevel}>Lv.{hero.level}</span>
-            </div>
+            </button>
           ))}
         </div>
       </div>

--- a/components/HubScreen.module.css
+++ b/components/HubScreen.module.css
@@ -91,6 +91,94 @@
   flex-shrink: 0;
 }
 
+/* Expedition Banner */
+.expeditionBanner {
+  background: rgba(245, 158, 11, 0.06);
+  border: 1px solid rgba(245, 158, 11, 0.15);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  animation: fadeIn 0.3s ease;
+}
+
+.bannerHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bannerIcon {
+  font-size: 1rem;
+}
+
+.bannerTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #f59e0b;
+  flex: 1;
+}
+
+.bannerViewBtn {
+  background: rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  color: #f59e0b;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.bannerViewBtn:active {
+  background: rgba(245, 158, 11, 0.3);
+}
+
+.expCard {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.expInfo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.expIcon {
+  font-size: 0.9rem;
+}
+
+.expName {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #e8e8f0;
+  flex: 1;
+}
+
+.expTime {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #f59e0b;
+  font-variant-numeric: tabular-nums;
+}
+
+.expBar {
+  height: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.expFill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 1s linear;
+}
+
 /* Next Goal Card */
 .goalCard {
   background: rgba(249, 115, 22, 0.06);
@@ -169,6 +257,67 @@
   text-align: right;
 }
 
+/* Loot Chests */
+.chestsSection {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.chestList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chestCard {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #e8e8f0;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.chestCard:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chestReady {
+  border-color: var(--chest-color);
+  animation: pulse 2s infinite;
+}
+
+.chestIcon {
+  font-size: 1.3rem;
+}
+
+.chestInfo {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chestLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--chest-color);
+}
+
+.chestTimer {
+  font-size: 0.65rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Nav Tiles */
 .grid {
   display: grid;
@@ -243,9 +392,18 @@
   align-items: center;
   gap: 6px;
   background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 8px;
   padding: 6px 10px;
   font-size: 0.75rem;
+  color: #e8e8f0;
+  cursor: pointer;
+  transition: background 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.heroChip:active {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .heroStatus {

--- a/components/RewardSummaryModal.jsx
+++ b/components/RewardSummaryModal.jsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { RESOURCES } from "@/data/resources";
+import { getRarityColor, getRarityLabel } from "@/lib/rarity";
+import Modal from "./shared/Modal";
+import styles from "./RewardSummaryModal.module.css";
+
+export default function RewardSummaryModal({ rewards, expeditionName, onCollect }) {
+  const hasItems = rewards.items && rewards.items.length > 0;
+  const hasResources = rewards.resources && Object.keys(rewards.resources).length > 0;
+
+  return (
+    <Modal title="Expedition Complete" onClose={onCollect}>
+      <div className={styles.summary}>
+        <h3 className={styles.expName}>{expeditionName}</h3>
+
+        {hasResources && (
+          <div className={styles.section}>
+            <h4 className={styles.label}>Resources</h4>
+            <div className={styles.resourceList}>
+              {Object.entries(rewards.resources).map(([res, amount]) =>
+                amount > 0 ? (
+                  <div key={res} className={styles.resourceChip}>
+                    <span className={styles.resourceIcon}>
+                      {RESOURCES[res]?.icon || res}
+                    </span>
+                    <span className={styles.resourceAmount}>+{amount}</span>
+                    <span className={styles.resourceName}>
+                      {RESOURCES[res]?.name || res}
+                    </span>
+                  </div>
+                ) : null
+              )}
+            </div>
+          </div>
+        )}
+
+        {hasItems && (
+          <div className={styles.section}>
+            <h4 className={styles.label}>Items Found</h4>
+            <div className={styles.itemList}>
+              {rewards.items.map((item) => (
+                <div
+                  key={item.id}
+                  className={styles.itemChip}
+                  style={{
+                    borderColor: getRarityColor(item.rarity),
+                    "--rarity-color": getRarityColor(item.rarity),
+                  }}
+                >
+                  <span className={styles.itemIcon}>{item.icon}</span>
+                  <div className={styles.itemInfo}>
+                    <span
+                      className={styles.itemName}
+                      style={{ color: getRarityColor(item.rarity) }}
+                    >
+                      {item.name}
+                    </span>
+                    <span className={styles.itemRarity}>
+                      {getRarityLabel(item.rarity)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!hasResources && !hasItems && (
+          <p className={styles.empty}>No rewards this time.</p>
+        )}
+
+        <button className={styles.collectBtn} onClick={onCollect}>
+          Collect
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/components/RewardSummaryModal.module.css
+++ b/components/RewardSummaryModal.module.css
@@ -1,0 +1,125 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.expName {
+  font-family: var(--font-dm-serif), serif;
+  font-size: 1rem;
+  color: #e8e8f0;
+  text-align: center;
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 0.65rem;
+  color: #8888a0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0;
+}
+
+.resourceList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.resourceChip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 6px 10px;
+}
+
+.resourceIcon {
+  font-size: 1rem;
+}
+
+.resourceAmount {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #22c55e;
+  font-variant-numeric: tabular-nums;
+}
+
+.resourceName {
+  font-size: 0.65rem;
+  color: #8888a0;
+}
+
+.itemList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.itemChip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid;
+  border-radius: 10px;
+  padding: 10px;
+  animation: fadeIn 0.3s ease;
+}
+
+.itemIcon {
+  font-size: 1.2rem;
+}
+
+.itemInfo {
+  display: flex;
+  flex-direction: column;
+}
+
+.itemName {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.itemRarity {
+  font-size: 0.6rem;
+  color: #6b6b80;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.empty {
+  text-align: center;
+  color: #6b6b80;
+  font-size: 0.8rem;
+  padding: 16px 0;
+}
+
+.collectBtn {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.collectBtn:active {
+  background: rgba(34, 197, 94, 0.25);
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/components/SeasonScreen.jsx
+++ b/components/SeasonScreen.jsx
@@ -26,6 +26,18 @@ export default function SeasonScreen() {
 
   const maxTrackXP = season.rewardTrack[season.rewardTrack.length - 1]?.xp || 800;
 
+  const dailyQuests = state.dailyQuests || { progress: {}, claimed: [] };
+  const DAILY_QUEST_DEFS = [
+    { id: "craft_3", label: "Craft 3 Items", key: "craftItems", target: 3, reward: { resources: { gold: 30 }, xp: 15 } },
+    { id: "expedition_2", label: "Complete 2 Expeditions", key: "completeExpeditions", target: 2, reward: { resources: { gold: 50, herbs: 10 }, xp: 25 } },
+    { id: "level_hero", label: "Level Up a Hero", key: "levelUpHero", target: 1, reward: { resources: { gold: 40 }, xp: 20 } },
+    { id: "sell_5", label: "Sell 5 Items", key: "sellItems", target: 5, reward: { resources: { gold: 20 }, xp: 10 } },
+  ];
+
+  const handleClaimDailyQuest = (quest) => {
+    dispatch({ type: "CLAIM_DAILY_QUEST", questId: quest.id, reward: quest.reward });
+  };
+
   return (
     <div className={styles.screen}>
       {/* Season Banner */}
@@ -59,6 +71,45 @@ export default function SeasonScreen() {
           color={RESOURCES[season.bonusResource]?.color || "#f97316"}
           label="Season XP"
         />
+      </div>
+
+      {/* Daily Quests */}
+      <div className={styles.track}>
+        <h3 className={styles.subheading}>Daily Quests</h3>
+        {DAILY_QUEST_DEFS.map((quest) => {
+          const progress = dailyQuests.progress[quest.key] || 0;
+          const complete = progress >= quest.target;
+          const claimed = dailyQuests.claimed.includes(quest.id);
+
+          return (
+            <div
+              key={quest.id}
+              className={`${styles.tier} ${claimed ? styles.tierClaimed : ""} ${complete && !claimed ? styles.tierReady : ""}`}
+            >
+              <div className={styles.tierXP}>{Math.min(progress, quest.target)}/{quest.target}</div>
+              <div className={styles.tierReward}>
+                <span className={styles.questLabel}>{quest.label}</span>
+                <div className={styles.questRewards}>
+                  {quest.reward.resources && Object.entries(quest.reward.resources).map(([res, amt]) => (
+                    <span key={res} className={styles.rewardChip}>
+                      {RESOURCES[res]?.icon} {amt}
+                    </span>
+                  ))}
+                  {quest.reward.xp > 0 && (
+                    <span className={styles.rewardChip}>{"\u2B50"} {quest.reward.xp} XP</span>
+                  )}
+                </div>
+              </div>
+              <button
+                className={styles.claimBtn}
+                disabled={claimed || !complete}
+                onClick={() => handleClaimDailyQuest(quest)}
+              >
+                {claimed ? "Done" : complete ? "Claim" : "..."}
+              </button>
+            </div>
+          );
+        })}
       </div>
 
       {/* Reward Track */}

--- a/components/SeasonScreen.module.css
+++ b/components/SeasonScreen.module.css
@@ -120,6 +120,19 @@
   color: #c0c0d4;
 }
 
+.questLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #e8e8f0;
+  display: block;
+}
+
+.questRewards {
+  display: flex;
+  gap: 6px;
+  margin-top: 2px;
+}
+
 .claimBtn {
   background: rgba(34, 197, 94, 0.15);
   color: #22c55e;

--- a/components/WorldMapScreen.jsx
+++ b/components/WorldMapScreen.jsx
@@ -5,10 +5,13 @@ import { useGameState, useGameDispatch } from "@/lib/gameContext";
 import { REGIONS } from "@/data/regions";
 import { EXPEDITIONS } from "@/data/expeditions";
 import { getRegionExpeditions, canSendExpedition, generateRewards, getEffectiveExpeditionDuration } from "@/lib/expedition";
+import { getExpeditionDurabilityCost } from "@/lib/rarity";
+import { getExpeditionEnduranceCost } from "@/lib/hero";
 import { RESOURCES } from "@/data/resources";
 import HeroCard from "./shared/HeroCard";
 import Modal from "./shared/Modal";
 import CombatReplayModal from "./CombatReplayModal";
+import RewardSummaryModal from "./RewardSummaryModal";
 import RegionDetailModal from "./RegionDetailModal";
 import styles from "./WorldMapScreen.module.css";
 
@@ -19,6 +22,7 @@ export default function WorldMapScreen() {
   const [selectedExpedition, setSelectedExpedition] = useState(null);
   const [selectedHeroes, setSelectedHeroes] = useState([]);
   const [combatPending, setCombatPending] = useState(null); // { combatResult, rewards, expeditionId }
+  const [rewardPending, setRewardPending] = useState(null); // { rewards, expeditionId, templateId, expeditionName }
 
   const now = Date.now();
   const idleHeroes = state.heroes.filter((h) => h.status === "idle");
@@ -71,15 +75,32 @@ export default function WorldMapScreen() {
     if (rewards.combatResult) {
       setCombatPending({ combatResult: rewards.combatResult, rewards, expeditionId: exp.id, templateId: exp.templateId });
     } else {
-      finalizeClaim(exp.id, rewards, exp.templateId);
+      setRewardPending({ rewards, expeditionId: exp.id, templateId: exp.templateId, expeditionName: template?.name || "Expedition" });
     }
   };
 
-  const finalizeClaim = (expeditionId, rewards, templateId) => {
+  const finalizeClaim = (expeditionId, rewards, templateId, combatOutcome) => {
+    const claimTemplate = EXPEDITIONS.find((e) => e.id === templateId);
+    const baseDurabilityCost = claimTemplate ? getExpeditionDurabilityCost(claimTemplate) : 0;
+    const baseEnduranceCost = claimTemplate ? getExpeditionEnduranceCost(claimTemplate) : 0;
+
+    // Graduated consequences based on combat outcome
+    let durabilityMult = 1.0;
+    let enduranceMult = 1.0;
+    if (combatOutcome === "draw") {
+      durabilityMult = 1.5;
+      enduranceMult = 1.5;
+    } else if (combatOutcome === "defeat") {
+      durabilityMult = 2.0;
+      enduranceMult = 2.0;
+    }
+
     dispatch({
       type: "CLAIM_REWARDS",
       expeditionId,
       rewards,
+      durabilityCost: Math.round(baseDurabilityCost * durabilityMult),
+      enduranceCost: Math.round(baseEnduranceCost * enduranceMult),
     });
 
     // Check if this is a boss expedition
@@ -114,7 +135,12 @@ export default function WorldMapScreen() {
 
   const handleCombatDone = () => {
     if (combatPending) {
-      finalizeClaim(combatPending.expeditionId, combatPending.rewards, combatPending.templateId);
+      const outcome = combatPending.combatResult.victory
+        ? "victory"
+        : combatPending.combatResult.isDraw
+        ? "draw"
+        : "defeat";
+      finalizeClaim(combatPending.expeditionId, combatPending.rewards, combatPending.templateId, outcome);
     }
   };
 
@@ -305,6 +331,18 @@ export default function WorldMapScreen() {
           combatResult={combatPending.combatResult}
           rewards={combatPending.rewards}
           onDone={handleCombatDone}
+        />
+      )}
+
+      {/* Reward Summary Modal (non-combat expeditions) */}
+      {rewardPending && (
+        <RewardSummaryModal
+          rewards={rewardPending.rewards}
+          expeditionName={rewardPending.expeditionName}
+          onCollect={() => {
+            finalizeClaim(rewardPending.expeditionId, rewardPending.rewards, rewardPending.templateId, "victory");
+            setRewardPending(null);
+          }}
         />
       )}
     </div>

--- a/components/shared/HeroCard.jsx
+++ b/components/shared/HeroCard.jsx
@@ -34,6 +34,22 @@ export default function HeroCard({ hero, inventory, onClick, selected = false })
         <span className={styles.stat}>{"\u{1F4A8}"} {hero.stats.spd}</span>
       </div>
 
+      {hero.endurance && (
+        <div className={styles.enduranceBar}>
+          <div
+            className={styles.enduranceFill}
+            style={{
+              width: `${(hero.endurance.current / hero.endurance.max) * 100}%`,
+              background: hero.endurance.current <= hero.endurance.max * 0.2
+                ? "#ef4444"
+                : hero.endurance.current <= hero.endurance.max * 0.5
+                ? "#f59e0b"
+                : "#22c55e",
+            }}
+          />
+        </div>
+      )}
+
       <div className={styles.footer}>
         <span className={styles.power}>Power: {power}</span>
         <span className={styles.status} style={{ color: statusColors[hero.status] }}>

--- a/components/shared/HeroCard.module.css
+++ b/components/shared/HeroCard.module.css
@@ -64,6 +64,20 @@
   font-variant-numeric: tabular-nums;
 }
 
+.enduranceBar {
+  height: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.enduranceFill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
 .footer {
   display: flex;
   justify-content: space-between;

--- a/components/shared/ItemCard.jsx
+++ b/components/shared/ItemCard.jsx
@@ -29,7 +29,7 @@ export default function ItemCard({ item, onClick, compact = false }) {
       </div>
       <div className={styles.info}>
         <span className={styles.name} style={{ color: rarityColor }}>
-          {item.name}
+          {item.name}{(item.level || 1) > 1 ? ` Lv.${item.level}` : ""}
         </span>
         <span className={styles.rarity}>{getRarityLabel(item.rarity)}</span>
         <div className={styles.stats}>
@@ -39,6 +39,21 @@ export default function ItemCard({ item, onClick, compact = false }) {
         </div>
       </div>
       {item.equippedBy && <span className={styles.equipped}>E</span>}
+      {item.durability && (
+        <div className={styles.durabilityBar}>
+          <div
+            className={styles.durabilityFill}
+            style={{
+              width: `${(item.durability.current / item.durability.max) * 100}%`,
+              background: item.durability.current <= 0
+                ? "#ef4444"
+                : item.durability.current < item.durability.max * 0.3
+                ? "#f59e0b"
+                : "#22c55e",
+            }}
+          />
+        </div>
+      )}
     </button>
   );
 }

--- a/components/shared/ItemCard.module.css
+++ b/components/shared/ItemCard.module.css
@@ -76,6 +76,23 @@
   border-radius: 4px;
 }
 
+.durabilityBar {
+  position: absolute;
+  bottom: 2px;
+  left: 8px;
+  right: 8px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 1px;
+  overflow: hidden;
+}
+
+.durabilityFill {
+  height: 100%;
+  border-radius: 1px;
+  transition: width 0.3s ease;
+}
+
 .compact {
   width: 42px;
   height: 42px;

--- a/data/heroes.js
+++ b/data/heroes.js
@@ -6,6 +6,8 @@ export const HERO_TEMPLATES = [
     icon: "\u2694\uFE0F",
     baseStats: { hp: 60, atk: 12, def: 10, spd: 4 },
     statGrowth: { hp: 8, atk: 2, def: 2, spd: 1 },
+    baseEndurance: 100,
+    enduranceGrowth: 5,
     unlockLevel: 1,
   },
   {
@@ -15,6 +17,8 @@ export const HERO_TEMPLATES = [
     icon: "\u{1F3F9}",
     baseStats: { hp: 40, atk: 10, def: 5, spd: 12 },
     statGrowth: { hp: 5, atk: 2, def: 1, spd: 3 },
+    baseEndurance: 80,
+    enduranceGrowth: 4,
     unlockLevel: 5,
   },
   {
@@ -24,6 +28,8 @@ export const HERO_TEMPLATES = [
     icon: "\u{1F9D9}",
     baseStats: { hp: 35, atk: 15, def: 3, spd: 8 },
     statGrowth: { hp: 4, atk: 3, def: 1, spd: 2 },
+    baseEndurance: 70,
+    enduranceGrowth: 3,
     unlockLevel: 10,
   },
   {
@@ -33,6 +39,8 @@ export const HERO_TEMPLATES = [
     icon: "\u{1F6E1}\uFE0F",
     baseStats: { hp: 70, atk: 8, def: 14, spd: 3 },
     statGrowth: { hp: 10, atk: 1, def: 3, spd: 1 },
+    baseEndurance: 120,
+    enduranceGrowth: 6,
     unlockLevel: 15,
   },
 ];

--- a/data/titles.js
+++ b/data/titles.js
@@ -1,0 +1,110 @@
+export const TITLES = [
+  // Expedition milestones
+  {
+    id: "first_blood",
+    name: "Blooded",
+    description: "Complete your first expedition",
+    bonus: { type: "expedition_gold", value: 0.05, label: "+5% expedition gold" },
+    condition: { stat: "totalExpeditions", threshold: 1 },
+  },
+  {
+    id: "veteran",
+    name: "Veteran",
+    description: "Complete 25 expeditions",
+    bonus: { type: "expedition_gold", value: 0.10, label: "+10% expedition gold" },
+    condition: { stat: "totalExpeditions", threshold: 25 },
+  },
+  {
+    id: "warlord",
+    name: "Warlord",
+    description: "Complete 100 expeditions",
+    bonus: { type: "endurance_drain", value: -0.10, label: "-10% endurance drain" },
+    condition: { stat: "totalExpeditions", threshold: 100 },
+  },
+
+  // Crafting milestones
+  {
+    id: "apprentice",
+    name: "Apprentice Smith",
+    description: "Craft 10 items",
+    bonus: { type: "craft_speed", value: 0.05, label: "+5% craft speed" },
+    condition: { stat: "totalItemsCrafted", threshold: 10 },
+  },
+  {
+    id: "master_smith",
+    name: "Master Smith",
+    description: "Craft 50 items",
+    bonus: { type: "craft_speed", value: 0.10, label: "+10% craft speed" },
+    condition: { stat: "totalItemsCrafted", threshold: 50 },
+  },
+
+  // Boss milestones
+  {
+    id: "boss_slayer",
+    name: "Boss Slayer",
+    description: "Defeat your first region boss",
+    bonus: { type: "durability_save", value: 1, label: "+1 durability saved per expedition" },
+    condition: { stat: "bossesDefeated", threshold: 1 },
+  },
+  {
+    id: "dragonslayer",
+    name: "Dragonslayer",
+    description: "Defeat 4 region bosses",
+    bonus: { type: "durability_save", value: 3, label: "+3 durability saved per expedition" },
+    condition: { stat: "bossesDefeated", threshold: 4 },
+  },
+
+  // Level milestones
+  {
+    id: "seasoned",
+    name: "Seasoned",
+    description: "Reach hero level 10",
+    bonus: { type: "rest_speed", value: -0.15, label: "-15% rest time" },
+    condition: { stat: "highestHeroLevel", threshold: 10 },
+  },
+  {
+    id: "legendary",
+    name: "Legendary",
+    description: "Reach hero level 20",
+    bonus: { type: "rest_speed", value: -0.25, label: "-25% rest time" },
+    condition: { stat: "highestHeroLevel", threshold: 20 },
+  },
+
+  // Discovery milestones
+  {
+    id: "explorer",
+    name: "Explorer",
+    description: "Discover 5 points of interest",
+    bonus: { type: "discovery_chance", value: 0.10, label: "+10% discovery chance" },
+    condition: { stat: "totalDiscoveries", threshold: 5 },
+  },
+
+  // Prestige milestones
+  {
+    id: "reborn",
+    name: "Reborn",
+    description: "Complete your first prestige rebirth",
+    bonus: { type: "xp_bonus", value: 0.05, label: "+5% player XP" },
+    condition: { stat: "prestigeTier", threshold: 1 },
+  },
+];
+
+export function getUnlockedTitles(stats, worldMap, prestige) {
+  const statMap = {
+    totalExpeditions: stats.totalExpeditions || 0,
+    totalItemsCrafted: stats.totalItemsCrafted || 0,
+    highestHeroLevel: stats.highestHeroLevel || 1,
+    bossesDefeated: Object.keys(worldMap?.bossesDefeated || {}).length,
+    totalDiscoveries: Object.keys(worldMap?.discoveries || {}).length,
+    prestigeTier: prestige?.tier || 0,
+  };
+
+  return TITLES.filter((title) => {
+    const value = statMap[title.condition.stat] || 0;
+    return value >= title.condition.threshold;
+  });
+}
+
+export function getTitleById(id) {
+  return TITLES.find((t) => t.id === id) || null;
+}

--- a/lib/crafting.js
+++ b/lib/crafting.js
@@ -1,5 +1,5 @@
 import { RECIPES } from "@/data/recipes";
-import { rollRarity, applyRarityMultiplier } from "./rarity";
+import { rollRarity, applyRarityMultiplier, getMaxDurability } from "./rarity";
 
 export function getRecipeById(recipeId) {
   return RECIPES.find((r) => r.id === recipeId);
@@ -20,6 +20,7 @@ export function generateItem(recipe) {
   const rarity = rollRarity();
   const stats = applyRarityMultiplier(recipe.baseStats, rarity);
 
+  const maxDur = getMaxDurability(recipe.tier, rarity.id);
   return {
     id: `item_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     recipeId: recipe.id,
@@ -28,6 +29,8 @@ export function generateItem(recipe) {
     slot: recipe.slot,
     tier: recipe.tier,
     rarity: rarity.id,
+    level: 1,
+    durability: { current: maxDur, max: maxDur },
     stats,
     equippedBy: null,
   };

--- a/lib/expedition.js
+++ b/lib/expedition.js
@@ -1,6 +1,6 @@
 import { EXPEDITIONS } from "@/data/expeditions";
 import { getHeroPower } from "./hero";
-import { rollRarity, applyRarityMultiplier } from "./rarity";
+import { rollRarity, applyRarityMultiplier, applyLevelMultiplier, rollItemLevel, getMaxDurability } from "./rarity";
 import { RECIPES } from "@/data/recipes";
 import { generateEnemyParty, resolveCombat, getCombatRewardMultiplier } from "./combat";
 import { getExpeditionDurationMultiplier } from "./skills";
@@ -24,10 +24,13 @@ export function canSendExpedition(expedition, selectedHeroes, allHeroes, invento
     return false;
   }
 
-  // Check all selected heroes are idle
+  // Check all selected heroes are idle and have enough endurance
+  const enduranceCost = getExpeditionEnduranceCost(expedition);
   for (const heroId of selectedHeroes) {
     const hero = allHeroes.find((h) => h.id === heroId);
     if (!hero || hero.status !== "idle") return false;
+    // Need at least minimum endurance to go on expedition
+    if (hero.endurance && hero.endurance.current < Math.min(enduranceCost, 10)) return false;
   }
 
   // Check combined power
@@ -37,6 +40,12 @@ export function canSendExpedition(expedition, selectedHeroes, allHeroes, invento
   }, 0);
 
   return totalPower >= expedition.requiredPower;
+}
+
+function getExpeditionEnduranceCost(expedition) {
+  const base = 15;
+  const levelScale = (expedition.unlockLevel || 1) * 2;
+  return Math.round(base + levelScale);
 }
 
 export function getEffectiveExpeditionDuration(expedition, heroIds, allHeroes) {
@@ -79,13 +88,18 @@ export function generateRewards(expedition, heroIds, allHeroes, inventory) {
     resources[resource] = Math.round(base * rewardMult);
   }
 
-  // Item drop chance
+  // Item drop chance — no items on draw or defeat
   const items = [];
-  if (Math.random() < expedition.rewards.itemChance * rewardMult) {
+  const canDropItems = !combatResult || combatResult.victory;
+  if (canDropItems && Math.random() < expedition.rewards.itemChance * rewardMult) {
     const eligible = RECIPES.filter((r) => r.unlockLevel <= expedition.unlockLevel);
     if (eligible.length > 0) {
       const recipe = eligible[Math.floor(Math.random() * eligible.length)];
       const rarity = rollRarity();
+      const level = rollItemLevel(expedition.unlockLevel);
+      const baseStats = applyRarityMultiplier(recipe.baseStats, rarity);
+      const stats = level > 1 ? applyLevelMultiplier(baseStats, level) : baseStats;
+      const maxDur = getMaxDurability(recipe.tier, rarity.id);
       items.push({
         id: `item_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         recipeId: recipe.id,
@@ -94,7 +108,9 @@ export function generateRewards(expedition, heroIds, allHeroes, inventory) {
         slot: recipe.slot,
         tier: recipe.tier,
         rarity: rarity.id,
-        stats: applyRarityMultiplier(recipe.baseStats, rarity),
+        level,
+        durability: { current: maxDur, max: maxDur },
+        stats,
         equippedBy: null,
       });
     }

--- a/lib/gameReducer.js
+++ b/lib/gameReducer.js
@@ -1,11 +1,26 @@
 import { getPrestigeMultiplier, getPrestigeStartingGold, getPrestigeStartingLevel, shouldUnlockAllHeroes, calculatePrestigeStars } from "./prestige";
+import { applyLevelMultiplier, getLevelMultiplier, getMaxDurability } from "./rarity";
 import { HERO_TEMPLATES } from "@/data/heroes";
 import { getUnlocksForLevel } from "@/data/progression";
 import { createHeroFromTemplate } from "./hero";
 
+function bumpDailyQuest(state, questKey, amount = 1) {
+  if (!state.dailyQuests) return state;
+  return {
+    ...state,
+    dailyQuests: {
+      ...state.dailyQuests,
+      progress: {
+        ...state.dailyQuests.progress,
+        [questKey]: (state.dailyQuests.progress[questKey] || 0) + amount,
+      },
+    },
+  };
+}
+
 export function createInitialState() {
   return {
-    version: 2,
+    version: 3,
 
     // Player
     player: {
@@ -38,6 +53,7 @@ export function createInitialState() {
 
     // Crafted items
     inventory: [],
+    inventoryCapacity: 20,
 
     // Active crafting (max 2 slots)
     craftingQueue: [],
@@ -53,6 +69,8 @@ export function createInitialState() {
         xp: 0,
         stats: { hp: 60, atk: 12, def: 10, spd: 4 },
         equipment: { weapon: null, armor: null, accessory: null },
+        endurance: { current: 100, max: 100 },
+        activeTitle: null,
         status: "idle",
       },
     ],
@@ -68,6 +86,18 @@ export function createInitialState() {
       currentWeek: 0,
       weeklyXP: 0,
       claimedRewards: [],
+    },
+
+    // Daily quests
+    dailyQuests: {
+      lastReset: Date.now(),
+      progress: {
+        craftItems: 0,
+        completeExpeditions: 0,
+        levelUpHero: 0,
+        sellItems: 0,
+      },
+      claimed: [],
     },
 
     // Lifetime stats
@@ -97,6 +127,13 @@ export function createInitialState() {
       titles: [],
     },
 
+    // Loot chests
+    chests: {
+      common: { lastClaimed: 0, cooldown: 4 * 60 * 60 * 1000 },    // 4 hours
+      uncommon: { lastClaimed: 0, cooldown: 8 * 60 * 60 * 1000 },   // 8 hours
+      rare: { lastClaimed: 0, cooldown: 24 * 60 * 60 * 1000 },      // 24 hours
+    },
+
     // UI state (not persisted meaningfully, but part of state for simplicity)
     currentScreen: "hub",
   };
@@ -105,7 +142,7 @@ export function createInitialState() {
 export function gameReducer(state, action) {
   switch (action.type) {
     case "SET_SCREEN":
-      return { ...state, currentScreen: action.screen };
+      return { ...state, currentScreen: action.screen, screenPayload: action.payload || null };
 
     case "TICK": {
       const now = action.now || Date.now();
@@ -139,9 +176,34 @@ export function gameReducer(state, action) {
         }
       }
 
+      // Reset daily quests at midnight (24h from last reset)
+      let dailyQuests = state.dailyQuests;
+      if (dailyQuests && now - dailyQuests.lastReset >= 24 * 60 * 60 * 1000) {
+        dailyQuests = {
+          lastReset: now,
+          progress: { craftItems: 0, completeExpeditions: 0, levelUpHero: 0, sellItems: 0 },
+          claimed: [],
+        };
+      }
+
+      // Check rest completion for heroes
+      const newHeroesTick = state.heroes.map((h) => {
+        if (h.status === "resting" && h.restUntil && now >= h.restUntil) {
+          return {
+            ...h,
+            status: "idle",
+            endurance: { ...h.endurance, current: h.endurance?.max || 100 },
+            restUntil: undefined,
+          };
+        }
+        return h;
+      });
+
       return {
         ...state,
         resources: newResources,
+        heroes: newHeroesTick,
+        dailyQuests,
         // craftingQueue stays as-is; completed crafts remain until user collects
         expeditions: {
           ...state.expeditions,
@@ -165,6 +227,7 @@ export function gameReducer(state, action) {
 
     case "START_CRAFT": {
       if (state.craftingQueue.length >= 2) return state;
+      if (state.inventory.length >= (state.inventoryCapacity || 20)) return state;
       const { recipe } = action;
 
       // Deduct resources
@@ -197,7 +260,7 @@ export function gameReducer(state, action) {
       const xpMult = getPrestigeMultiplier(state.prestige, "player_xp_mult");
       const xpGain = Math.round(10 * xpMult);
 
-      return {
+      return bumpDailyQuest({
         ...state,
         craftingQueue: state.craftingQueue.filter((c) => c.id !== craftId),
         inventory: [...state.inventory, item],
@@ -213,7 +276,7 @@ export function gameReducer(state, action) {
           ...state.stats,
           totalItemsCrafted: state.stats.totalItemsCrafted + 1,
         },
-      };
+      }, "craftItems");
     }
 
     case "CANCEL_CRAFT": {
@@ -233,13 +296,58 @@ export function gameReducer(state, action) {
 
     case "SELL_ITEM": {
       const { itemId, goldValue } = action;
-      return {
+      return bumpDailyQuest({
         ...state,
         inventory: state.inventory.filter((i) => i.id !== itemId),
         resources: {
           ...state.resources,
           gold: state.resources.gold + goldValue,
         },
+      }, "sellItems");
+    }
+
+    case "SELL_ITEMS_BATCH": {
+      const { itemIds, totalGold } = action;
+      return {
+        ...state,
+        inventory: state.inventory.filter((i) => !itemIds.includes(i.id)),
+        resources: {
+          ...state.resources,
+          gold: state.resources.gold + totalGold,
+        },
+      };
+    }
+
+    case "UPGRADE_ITEM": {
+      const { itemId, cost } = action;
+      const item = state.inventory.find((i) => i.id === itemId);
+      if (!item) return state;
+      const currentLevel = item.level || 1;
+      if (currentLevel >= 3) return state;
+
+      // Check resources
+      const newResources = { ...state.resources };
+      for (const [res, amount] of Object.entries(cost)) {
+        if ((newResources[res] || 0) < amount) return state;
+        newResources[res] -= amount;
+      }
+
+      const newLevel = currentLevel + 1;
+      // Recalculate stats from base: strip old level mult, apply new
+      const oldMult = getLevelMultiplier(currentLevel);
+      const newMult = getLevelMultiplier(newLevel);
+      const newStats = {};
+      for (const [stat, value] of Object.entries(item.stats)) {
+        const baseValue = Math.round(value / oldMult);
+        newStats[stat] = Math.round(baseValue * newMult);
+      }
+
+      return {
+        ...state,
+        resources: newResources,
+        inventory: state.inventory.map((i) =>
+          i.id === itemId ? { ...i, level: newLevel, stats: newStats } : i
+        ),
       };
     }
 
@@ -288,7 +396,7 @@ export function gameReducer(state, action) {
     }
 
     case "LEVEL_UP_HERO": {
-      const { heroId: lvHeroId, cost, statGrowth } = action;
+      const { heroId: lvHeroId, cost, statGrowth, enduranceGrowth } = action;
       if (state.resources.gold < cost) return state;
 
       const heroXpMult = getPrestigeMultiplier(state.prestige, "hero_xp_mult");
@@ -297,6 +405,8 @@ export function gameReducer(state, action) {
 
       const newHeroes = state.heroes.map((h) => {
         if (h.id !== lvHeroId) return h;
+        const endGrowth = enduranceGrowth || 5;
+        const newMax = (h.endurance?.max || 100) + endGrowth;
         return {
           ...h,
           level: h.level + 1,
@@ -306,12 +416,16 @@ export function gameReducer(state, action) {
             def: h.stats.def + statGrowth.def,
             spd: h.stats.spd + statGrowth.spd,
           },
+          endurance: {
+            current: Math.min((h.endurance?.current || 100) + endGrowth, newMax),
+            max: newMax,
+          },
         };
       });
 
       const maxLevel = Math.max(...newHeroes.map((h) => h.level));
 
-      return {
+      return bumpDailyQuest({
         ...state,
         resources: { ...state.resources, gold: state.resources.gold - cost },
         heroes: newHeroes,
@@ -324,7 +438,7 @@ export function gameReducer(state, action) {
           ...state.stats,
           highestHeroLevel: Math.max(state.stats.highestHeroLevel, maxLevel),
         },
-      };
+      }, "levelUpHero");
     }
 
     case "RECRUIT_HERO": {
@@ -363,17 +477,168 @@ export function gameReducer(state, action) {
       };
     }
 
+    case "REPAIR_ITEM": {
+      const { itemId: repItemId, cost: repCost } = action;
+      const repItem = state.inventory.find((i) => i.id === repItemId);
+      if (!repItem || !repItem.durability) return state;
+      if (repItem.durability.current >= repItem.durability.max) return state;
+
+      const repResources = { ...state.resources };
+      for (const [res, amount] of Object.entries(repCost)) {
+        if ((repResources[res] || 0) < amount) return state;
+        repResources[res] -= amount;
+      }
+
+      return {
+        ...state,
+        resources: repResources,
+        inventory: state.inventory.map((i) =>
+          i.id === repItemId
+            ? { ...i, durability: { ...i.durability, current: i.durability.max } }
+            : i
+        ),
+      };
+    }
+
+    case "DISMANTLE_ITEM": {
+      const { itemId: disItemId, returns } = action;
+      const disItem = state.inventory.find((i) => i.id === disItemId);
+      if (!disItem || disItem.equippedBy) return state;
+
+      const disResources = { ...state.resources };
+      for (const [res, amount] of Object.entries(returns)) {
+        disResources[res] = (disResources[res] || 0) + amount;
+      }
+
+      return {
+        ...state,
+        resources: disResources,
+        inventory: state.inventory.filter((i) => i.id !== disItemId),
+      };
+    }
+
+    case "CLAIM_DAILY_QUEST": {
+      const { questId, reward: dqReward } = action;
+      if (!state.dailyQuests || state.dailyQuests.claimed.includes(questId)) return state;
+
+      const dqResources = { ...state.resources };
+      if (dqReward.resources) {
+        for (const [res, amount] of Object.entries(dqReward.resources)) {
+          dqResources[res] = (dqResources[res] || 0) + amount;
+        }
+      }
+
+      const dqXpMult = getPrestigeMultiplier(state.prestige, "player_xp_mult");
+      const dqXpGain = Math.round((dqReward.xp || 0) * dqXpMult);
+
+      return {
+        ...state,
+        resources: dqResources,
+        dailyQuests: {
+          ...state.dailyQuests,
+          claimed: [...state.dailyQuests.claimed, questId],
+        },
+        player: { ...state.player, xp: state.player.xp + dqXpGain },
+        season: {
+          ...state.season,
+          weeklyXP: state.season.weeklyXP + dqXpGain,
+        },
+      };
+    }
+
+    case "CLAIM_CHEST": {
+      const { chestType, rewards: chestRewards } = action;
+      const chest = state.chests?.[chestType];
+      if (!chest) return state;
+
+      const now = Date.now();
+      if (now - chest.lastClaimed < chest.cooldown) return state;
+
+      const newResources = { ...state.resources };
+      if (chestRewards.resources) {
+        for (const [res, amount] of Object.entries(chestRewards.resources)) {
+          newResources[res] = (newResources[res] || 0) + amount;
+        }
+      }
+
+      const newInventory = chestRewards.items
+        ? [...state.inventory, ...chestRewards.items]
+        : [...state.inventory];
+
+      return {
+        ...state,
+        resources: newResources,
+        inventory: newInventory,
+        chests: {
+          ...state.chests,
+          [chestType]: { ...chest, lastClaimed: now },
+        },
+      };
+    }
+
+    case "SET_ACTIVE_TITLE": {
+      const { heroId: titleHeroId, titleId } = action;
+      return {
+        ...state,
+        heroes: state.heroes.map((h) =>
+          h.id === titleHeroId ? { ...h, activeTitle: titleId } : h
+        ),
+      };
+    }
+
+    case "REST_HERO": {
+      const { heroId: restHeroId, duration: restDuration } = action;
+      const restHero = state.heroes.find((h) => h.id === restHeroId);
+      if (!restHero || restHero.status !== "idle") return state;
+      if (restHero.endurance && restHero.endurance.current >= restHero.endurance.max) return state;
+
+      return {
+        ...state,
+        heroes: state.heroes.map((h) =>
+          h.id === restHeroId
+            ? { ...h, status: "resting", restUntil: Date.now() + restDuration }
+            : h
+        ),
+      };
+    }
+
+    case "USE_POTION": {
+      const { heroId: potHeroId, cost: potCost } = action;
+      const potHero = state.heroes.find((h) => h.id === potHeroId);
+      if (!potHero || potHero.status !== "idle") return state;
+
+      const potResources = { ...state.resources };
+      for (const [res, amount] of Object.entries(potCost)) {
+        if ((potResources[res] || 0) < amount) return state;
+        potResources[res] -= amount;
+      }
+
+      return {
+        ...state,
+        resources: potResources,
+        heroes: state.heroes.map((h) =>
+          h.id === potHeroId
+            ? { ...h, endurance: { ...h.endurance, current: h.endurance?.max || 100 } }
+            : h
+        ),
+      };
+    }
+
     case "CLAIM_REWARDS": {
-      const { expeditionId, rewards } = action;
+      const { expeditionId, rewards, durabilityCost, enduranceCost } = action;
       const exp = state.expeditions.completed.find(
         (e) => e.id === expeditionId
       );
       if (!exp) return state;
 
-      // Free up heroes
-      const newHeroes = state.heroes.map((h) =>
-        exp.heroIds.includes(h.id) ? { ...h, status: "idle" } : h
-      );
+      // Free up heroes and drain endurance
+      const newHeroes = state.heroes.map((h) => {
+        if (!exp.heroIds.includes(h.id)) return h;
+        const newEndurance = h.endurance
+          ? { ...h.endurance, current: Math.max(0, h.endurance.current - (enduranceCost || 0)) }
+          : h.endurance;
+        return { ...h, status: "idle", endurance: newEndurance };
+      });
 
       // Add resource rewards
       const newResources = { ...state.resources };
@@ -383,15 +648,39 @@ export function gameReducer(state, action) {
         }
       }
 
+      // Degrade durability on equipped weapons of heroes who went on expedition
+      let degradedInventory = [...state.inventory];
+      if (durabilityCost > 0) {
+        const heroesOnExp = state.heroes.filter((h) => exp.heroIds.includes(h.id));
+        const equippedItemIds = new Set();
+        for (const hero of heroesOnExp) {
+          for (const itemId of Object.values(hero.equipment)) {
+            if (itemId) equippedItemIds.add(itemId);
+          }
+        }
+        degradedInventory = degradedInventory.map((item) => {
+          if (equippedItemIds.has(item.id) && item.durability) {
+            return {
+              ...item,
+              durability: {
+                ...item.durability,
+                current: Math.max(0, item.durability.current - durabilityCost),
+              },
+            };
+          }
+          return item;
+        });
+      }
+
       // Add item rewards
       const newInventory = rewards.items
-        ? [...state.inventory, ...rewards.items]
-        : state.inventory;
+        ? [...degradedInventory, ...rewards.items]
+        : degradedInventory;
 
       const xpMult = getPrestigeMultiplier(state.prestige, "player_xp_mult");
       const xpGain = Math.round(25 * xpMult);
 
-      return {
+      return bumpDailyQuest({
         ...state,
         heroes: newHeroes,
         resources: newResources,
@@ -407,7 +696,7 @@ export function gameReducer(state, action) {
           ...state.season,
           weeklyXP: state.season.weeklyXP + xpGain,
         },
-      };
+      }, "completeExpeditions");
     }
 
     case "CLAIM_SEASON_REWARD": {

--- a/lib/hero.js
+++ b/lib/hero.js
@@ -15,6 +15,8 @@ export function getEffectiveStats(hero, inventory) {
     if (!itemId) continue;
     const item = inventory.find((i) => i.id === itemId);
     if (!item) continue;
+    // Items at 0 durability contribute no stats
+    if (item.durability && item.durability.current <= 0) continue;
     for (const [stat, value] of Object.entries(item.stats)) {
       if (base[stat] !== undefined) {
         base[stat] += value;
@@ -41,6 +43,7 @@ export function canLevelUp(hero, gold) {
 }
 
 export function createHeroFromTemplate(template) {
+  const maxEndurance = template.baseEndurance || 100;
   return {
     id: `hero_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     templateId: template.id,
@@ -50,7 +53,35 @@ export function createHeroFromTemplate(template) {
     xp: 0,
     stats: { ...template.baseStats },
     equipment: { weapon: null, armor: null, accessory: null },
+    endurance: { current: maxEndurance, max: maxEndurance },
+    activeTitle: null,
     status: "idle",
+  };
+}
+
+export function getHeroMaxEndurance(hero) {
+  const template = getHeroTemplate(hero.templateId);
+  if (!template) return 100;
+  return (template.baseEndurance || 100) + ((hero.level - 1) * (template.enduranceGrowth || 5));
+}
+
+export function getExpeditionEnduranceCost(expedition) {
+  const base = 15;
+  const levelScale = (expedition.unlockLevel || 1) * 2;
+  return Math.round(base + levelScale);
+}
+
+export function getRestDuration(hero) {
+  const missing = (hero.endurance?.max || 100) - (hero.endurance?.current || 0);
+  // 1 second per 1 endurance point
+  return missing * 1000;
+}
+
+export function getPotionCost(hero) {
+  const missing = (hero.endurance?.max || 100) - (hero.endurance?.current || 0);
+  return {
+    herbs: Math.max(3, Math.round(missing * 0.15)),
+    gold: Math.round(missing * 0.5),
   };
 }
 

--- a/lib/rarity.js
+++ b/lib/rarity.js
@@ -36,10 +36,87 @@ export function getRarityLabel(rarityId) {
   return (getRarityById(rarityId) || RARITIES[0]).label;
 }
 
-export function getSellValue(recipe, rarity) {
+// ── Item Level System ──
+const LEVEL_MULTIPLIERS = { 1: 1.0, 2: 1.35, 3: 1.8 };
+
+export function getLevelMultiplier(level) {
+  return LEVEL_MULTIPLIERS[level] || 1.0;
+}
+
+export function applyLevelMultiplier(stats, level) {
+  const mult = getLevelMultiplier(level);
+  const result = {};
+  for (const [stat, value] of Object.entries(stats)) {
+    result[stat] = Math.round(value * mult);
+  }
+  return result;
+}
+
+export function getUpgradeCost(item) {
+  const nextLevel = (item.level || 1) + 1;
+  if (nextLevel > 3) return null;
+  const tierMult = item.tier || 1;
+  const rarityObj = getRarityById(item.rarity);
+  return {
+    gold: Math.round(tierMult * 50 * nextLevel * rarityObj.multiplier),
+    iron: Math.round(tierMult * 10 * nextLevel),
+    gems: nextLevel >= 3 ? Math.round(tierMult * 2) : 0,
+  };
+}
+
+export function rollItemLevel(expeditionUnlockLevel) {
+  // Higher level expeditions have better chance of Lv 2/3 drops
+  const roll = Math.random() * 100;
+  if (expeditionUnlockLevel >= 10 && roll < 5) return 3;
+  if (expeditionUnlockLevel >= 7 && roll < 15) return 2;
+  if (expeditionUnlockLevel >= 4 && roll < 25) return 2;
+  return 1;
+}
+
+// ── Durability System ──
+const BASE_DURABILITY = { 1: 30, 2: 50, 3: 80 };
+const RARITY_DURABILITY_MULT = { common: 1.0, uncommon: 1.2, rare: 1.5, epic: 2.0 };
+
+export function getMaxDurability(tier, rarity) {
+  const base = BASE_DURABILITY[tier] || 30;
+  const mult = RARITY_DURABILITY_MULT[rarity] || 1.0;
+  return Math.round(base * mult);
+}
+
+export function getRepairCost(item) {
+  const missing = (item.durability?.max || 30) - (item.durability?.current || 0);
+  if (missing <= 0) return null;
+  const tierMult = item.tier || 1;
+  return {
+    gold: Math.round(missing * tierMult * 0.5),
+    iron: Math.round(missing * 0.3),
+  };
+}
+
+export function getDismantleReturns(item) {
+  const tierMult = item.tier || 1;
+  const rarityObj = getRarityById(item.rarity);
+  const durabilityRatio = (item.durability?.current || 0) / (item.durability?.max || 1);
+  const baseMult = 0.2 + durabilityRatio * 0.3; // 20-50% return based on durability
+  return {
+    iron: Math.round(tierMult * 8 * rarityObj.multiplier * baseMult),
+    stone: Math.round(tierMult * 5 * baseMult),
+    gold: Math.round(tierMult * 15 * rarityObj.multiplier * baseMult),
+  };
+}
+
+export function getExpeditionDurabilityCost(expedition) {
+  // Higher level expeditions cost more durability
+  const base = 5;
+  const levelScale = (expedition.unlockLevel || 1) * 0.8;
+  return Math.round(base + levelScale);
+}
+
+export function getSellValue(recipe, rarity, level) {
   const r = typeof rarity === "string" ? getRarityById(rarity) : rarity;
+  const lvMult = getLevelMultiplier(level || 1);
   // Base sell = 40% of gold ingredient cost + tier bonus
   const goldCost = recipe.ingredients.gold || 0;
   const tierBonus = recipe.tier * 10;
-  return Math.round((goldCost * 0.4 + tierBonus) * r.multiplier);
+  return Math.round((goldCost * 0.4 + tierBonus) * r.multiplier * lvMult);
 }

--- a/lib/save.js
+++ b/lib/save.js
@@ -1,5 +1,5 @@
 const SAVE_KEY = "forgeAndField_save";
-const CURRENT_VERSION = 2;
+const CURRENT_VERSION = 3;
 
 export function loadGame() {
   if (typeof window === "undefined") return null;
@@ -66,5 +66,57 @@ function migrate(data) {
     }
     data.version = 2;
   }
+
+  if (data.version < 3) {
+    // Add endurance to heroes
+    if (data.heroes) {
+      data.heroes = data.heroes.map((hero) => {
+        if (!hero.endurance) {
+          hero.endurance = { current: 100, max: 100 };
+        }
+        return hero;
+      });
+    }
+    // Add level and durability to items
+    if (data.inventory) {
+      data.inventory = data.inventory.map((item) => {
+        if (!item.level) item.level = 1;
+        if (!item.durability) {
+          const baseDur = { 1: 30, 2: 50, 3: 80 };
+          const rarityMult = { common: 1.0, uncommon: 1.2, rare: 1.5, epic: 2.0 };
+          const maxDur = Math.round((baseDur[item.tier] || 30) * (rarityMult[item.rarity] || 1.0));
+          item.durability = { current: maxDur, max: maxDur };
+        }
+        return item;
+      });
+    }
+    // Add activeTitle to heroes
+    if (data.heroes) {
+      data.heroes = data.heroes.map((hero) => {
+        if (hero.activeTitle === undefined) hero.activeTitle = null;
+        return hero;
+      });
+    }
+    // Add inventory capacity
+    if (!data.inventoryCapacity) data.inventoryCapacity = 20;
+    // Add chests
+    if (!data.chests) {
+      data.chests = {
+        common: { lastClaimed: 0, cooldown: 4 * 60 * 60 * 1000 },
+        uncommon: { lastClaimed: 0, cooldown: 8 * 60 * 60 * 1000 },
+        rare: { lastClaimed: 0, cooldown: 24 * 60 * 60 * 1000 },
+      };
+    }
+    // Add daily quests
+    if (!data.dailyQuests) {
+      data.dailyQuests = {
+        lastReset: Date.now(),
+        progress: { craftItems: 0, completeExpeditions: 0, levelUpHero: 0, sellItems: 0 },
+        claimed: [],
+      };
+    }
+    data.version = 3;
+  }
+
   return { ...data, version: CURRENT_VERSION };
 }


### PR DESCRIPTION
## Summary
- **12 GitHub issues** implemented across weapon systems, hero mechanics, UX improvements, and engagement features
- **1,986 lines added** across 25 files (3 new components, 1 new data file)
- Save migration v2→v3 ensures backward compatibility for existing players
- Build verified clean

## Phase 1 — High Priority (7 issues)
- **#13** Fix expedition reward pop-up — `RewardSummaryModal` for non-combat expeditions
- **#1** Hero clickable on hub → navigates to barracks with hero pre-selected
- **#2** Active expedition progress banners on hub screen
- **#3** Inventory multiselect with long-press for batch sell
- **#9** Weapon level tiers (Lv 1/2/3) with upgrade mechanic
- **#10** Weapon durability — degradation, repair, and dismantle
- **#4** Hero endurance/fatigue — rest mechanic + potion recovery

## Phase 2 — Medium Priority (5 issues)
- **#14/#15** Graduated expedition consequences (victory/draw/defeat scaling)
- **#5** Titles system — 11 milestone-based titles with passive bonuses
- **#19** Inventory capacity (default 20 slots, blocks crafting when full)
- **#16** Timed loot chests (common 4h / uncommon 8h / rare 24h)
- **#17** Daily quests on season screen with auto-reset

## Test plan
- [ ] Verify new game starts correctly with all new fields (endurance, durability, chests, daily quests)
- [ ] Load an existing save and confirm v2→v3 migration adds defaults
- [ ] Craft items, verify level=1 and durability assigned
- [ ] Complete expeditions, verify durability drain and endurance drain
- [ ] Test draw/defeat outcomes for graduated consequences
- [ ] Test hero rest + potion recovery
- [ ] Test weapon repair, dismantle, and upgrade flows
- [ ] Test batch sell via long-press in inventory
- [ ] Test loot chest claim and cooldown timers
- [ ] Test daily quest progress tracking and claim
- [ ] Test title unlock and equip on hero
- [ ] Verify prestige rebirth preserves new systems correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)