### PR TITLE
Fix iPhone nav bar clipping (#42)

### DIFF
--- a/.claude/communication.json
+++ b/.claude/communication.json
@@ -1,0 +1,9 @@
+{
+  "platform": "discord",
+  "channels": {
+    "default": "1484271134441607258",
+    "approvals": "1484271134441607258",
+    "notifications": "1484271134441607258",
+    "questions": "1484271134441607258"
+  }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -44,6 +44,7 @@ export const viewport = {
   width: "device-width",
   initialScale: 1,
   maximumScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({ children }) {


### PR DESCRIPTION
## Summary
- Adds `viewportFit: "cover"` to the Next.js viewport export in `app/layout.js`
- Without this, iOS Safari never exposes `env(safe-area-inset-bottom)` values, so the NavBar bottom padding was effectively 0 — clipped by the home indicator
- Also adds `.claude/communication.json` for Discord channel routing

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Open on iPhone Safari — verify bottom nav is fully visible with no clipping
- [ ] Verify no layout changes on Android/desktop

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)