### PR TITLE
Fix Buried Workshop not granting crafting slot

### DIFF
--- a/components/ForgeScreen.jsx
+++ b/components/ForgeScreen.jsx
@@ -22,8 +22,10 @@ export default function ForgeScreen() {
 
   const recipes = getAvailableRecipes(state.player.level);
 
+  const maxSlots = state.maxCraftSlots || 2;
+
   const handleCraft = (recipe) => {
-    if (state.craftingQueue.length >= 2) return;
+    if (state.craftingQueue.length >= maxSlots) return;
     if (!canCraft(recipe, state.resources)) return;
     dispatch({ type: "START_CRAFT", recipe });
   };
@@ -178,7 +180,7 @@ export default function ForgeScreen() {
         <div className={styles.recipeList}>
           {recipes.map((recipe) => {
             const affordable = canCraft(recipe, state.resources);
-            const queueFull = state.craftingQueue.length >= 2;
+            const queueFull = state.craftingQueue.length >= maxSlots;
             const invFull = state.inventory.length >= (state.inventoryCapacity || 20);
 
             return (

--- a/lib/gameReducer.js
+++ b/lib/gameReducer.js
@@ -20,7 +20,7 @@ function bumpDailyQuest(state, questKey, amount = 1) {
 
 export function createInitialState() {
   return {
-    version: 3,
+    version: 4,
 
     // Player
     player: {
@@ -55,7 +55,8 @@ export function createInitialState() {
     inventory: [],
     inventoryCapacity: 20,
 
-    // Active crafting (max 2 slots)
+    // Active crafting
+    maxCraftSlots: 2,
     craftingQueue: [],
 
     // Hero roster
@@ -229,7 +230,7 @@ export function gameReducer(state, action) {
     }
 
     case "START_CRAFT": {
-      if (state.craftingQueue.length >= 2) return state;
+      if (state.craftingQueue.length >= (state.maxCraftSlots || 2)) return state;
       if (state.inventory.length >= (state.inventoryCapacity || 20)) return state;
       const { recipe } = action;
 
@@ -859,6 +860,11 @@ export function gameReducer(state, action) {
             },
           };
         }
+      } else if (reward.type === "crafting_slot") {
+        newState = {
+          ...newState,
+          maxCraftSlots: (newState.maxCraftSlots || 2) + (reward.bonus || 1),
+        };
       } else if (reward.type === "xp_boost") {
         // XP boost is handled via discoveries check — stored in worldMap.discoveries
         // The prestige multiplier system handles it
@@ -915,6 +921,7 @@ export function gameReducer(state, action) {
         prestige: newPrestige,
         // Preserve village buildings across rebirths
         village: state.village || {},
+        maxCraftSlots: state.maxCraftSlots || 2,
         inventoryCapacity: state.inventoryCapacity || 20,
         stats: {
           ...state.stats, // Preserve lifetime stats

--- a/lib/save.js
+++ b/lib/save.js
@@ -1,5 +1,5 @@
 const SAVE_KEY = "forgeAndField_save";
-const CURRENT_VERSION = 3;
+const CURRENT_VERSION = 4;
 
 export function loadGame() {
   if (typeof window === "undefined") return null;
@@ -118,6 +118,13 @@ function migrate(data) {
     // Add village
     if (!data.village) data.village = {};
     data.version = 3;
+  }
+
+  if (data.version < 4) {
+    // Add maxCraftSlots and retroactively grant bonus if Buried Workshop was discovered
+    const hasWorkshop = data.worldMap?.discoveries?.poi_buried_workshop;
+    data.maxCraftSlots = hasWorkshop ? 3 : 2;
+    data.version = 4;
   }
 
   return { ...data, version: CURRENT_VERSION };


### PR DESCRIPTION
## Summary
- Add `maxCraftSlots` field to game state (default 2), replacing hardcoded slot limits
- Handle `crafting_slot` reward type in `DISCOVER_POI` — discovering the Buried Workshop now increments `maxCraftSlots`
- Save migration v3→v4 retroactively grants the extra slot for players who already discovered the Buried Workshop
- Preserve `maxCraftSlots` across prestige rebirths (since discoveries are preserved)
- ForgeScreen uses dynamic slot count for queue-full checks

## Test plan
- [ ] New game: verify 2 crafting slots by default
- [ ] Discover Buried Workshop via expedition — confirm slot count increases to 3
- [ ] Existing save with Buried Workshop already discovered — load and verify 3 slots after migration
- [ ] Existing save without Buried Workshop — load and verify 2 slots
- [ ] Prestige rebirth — confirm `maxCraftSlots` carries over
- [ ] Fill all slots and verify "Queue Full" shows correctly at the new limit

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)